### PR TITLE
fix: improve error messages when viewing non WSI images

### DIFF
--- a/src/main/java/com/quantumsoft/qupathcloud/configuration/MetadataConfiguration.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/configuration/MetadataConfiguration.java
@@ -21,6 +21,7 @@ import com.quantumsoft.qupathcloud.entities.Series;
 import com.quantumsoft.qupathcloud.entities.instance.Instance;
 import com.quantumsoft.qupathcloud.exception.QuPathCloudException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -118,5 +119,9 @@ public class MetadataConfiguration {
     } catch (IOException e) {
       throw new QuPathCloudException(e);
     }
+  }
+
+  public boolean exists(){
+    return Files.exists(projectMetadataIndexFile);
   }
 }

--- a/src/main/java/com/quantumsoft/qupathcloud/converter/dicomizer/ImageToWsiDcmConverter.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/converter/dicomizer/ImageToWsiDcmConverter.java
@@ -67,7 +67,7 @@ public class ImageToWsiDcmConverter {
     }
   }
 
-  private void configurePyramidParameters(Dicomizer.Options options) {
+  private void configurePyramidParameters(Dicomizer.Options options) throws QuPathCloudException {
     try (OpenSlide os = new OpenSlide(pathToImage.toFile())) {
       long totalWidth = os.getLevel0Width();
       long totalHeight = os.getLevel0Height();
@@ -107,7 +107,7 @@ public class ImageToWsiDcmConverter {
         options.generatePyramid(levels);
       }
     } catch (Throwable e) {
-      LOGGER.error("Failed to determine input file tiling via Openslide, setting defaults ", e);
+      throw new QuPathCloudException(e);
     }
   }
 

--- a/src/main/java/com/quantumsoft/qupathcloud/entities/DicomAttribute.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/entities/DicomAttribute.java
@@ -37,6 +37,16 @@ public class DicomAttribute<T> {
   private T[] Value;
 
   /**
+   * Check if is tag is empty.
+   *
+   * @return result of tag empty check
+   */
+  @JsonIgnore
+  public boolean isEmpty() {
+    return Value == null || Value.length == 0;
+  }
+
+  /**
    * Gets vr.
    *
    * @return the vr

--- a/src/main/java/com/quantumsoft/qupathcloud/entities/Series.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/entities/Series.java
@@ -79,7 +79,7 @@ public class Series {
    * @return the Series Description
    */
   public DicomAttribute<String> getSeriesDescription() {
-    if (seriesDescription == null) {
+    if (seriesDescription == null || seriesDescription.isEmpty()) {
       String temp = studyInstanceUID.getValue1() + seriesInstanceUID.getValue1();
       seriesDescription = new DicomAttribute<>();
       seriesDescription.setValue(new String[]{String.valueOf(temp.hashCode())});

--- a/src/main/java/com/quantumsoft/qupathcloud/synchronization/SynchronizationProjectWithDicomStore.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/synchronization/SynchronizationProjectWithDicomStore.java
@@ -206,11 +206,13 @@ public class SynchronizationProjectWithDicomStore {
     List<Series> remoteImageSeriesList = DaoHelper.getImageSeries(remoteSeriesList);
 
     List<Series> seriesListInProject;
-    if (Files.notExists(metadataDirectory)) {
-      try {
-        Files.createDirectory(metadataDirectory);
-      } catch (IOException e) {
-        throw new QuPathCloudException(e);
+    if (!metadataConfiguration.exists()) {
+      if (Files.notExists(metadataDirectory)) {
+        try {
+          Files.createDirectory(metadataDirectory);
+        } catch (IOException e) {
+          throw new QuPathCloudException(e);
+        }
       }
       seriesListInProject = new ArrayList<>();
       seriesProcess(remoteImageSeriesList, metadataConfiguration, seriesListInProject);


### PR DESCRIPTION
[#29]
If a user tries to synchronize non-WSI image, the error "Not a file that OpenSlide can recognize" will be shown.
![Screenshot from 2019-12-24 12-49-49](https://user-images.githubusercontent.com/39695947/71396555-331b8400-264d-11ea-9180-cf793babd53b.png)

