### PR TITLE
[#29] FR: Improve error messages when viewing non WSI images, part 2

### DIFF
--- a/src/main/java/com/quantumsoft/qupathcloud/configuration/MetadataConfiguration.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/configuration/MetadataConfiguration.java
@@ -21,6 +21,7 @@ import com.quantumsoft.qupathcloud.entities.Series;
 import com.quantumsoft.qupathcloud.entities.instance.Instance;
 import com.quantumsoft.qupathcloud.exception.QuPathCloudException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -118,5 +119,9 @@ public class MetadataConfiguration {
     } catch (IOException e) {
       throw new QuPathCloudException(e);
     }
+  }
+
+  public boolean exists(){
+    return Files.exists(projectMetadataIndexFile);
   }
 }

--- a/src/main/java/com/quantumsoft/qupathcloud/entities/DicomAttribute.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/entities/DicomAttribute.java
@@ -37,6 +37,16 @@ public class DicomAttribute<T> {
   private T[] Value;
 
   /**
+   * Check if is tag is empty.
+   *
+   * @return result of tag empty check
+   */
+  @JsonIgnore
+  public boolean isEmpty() {
+    return Value == null || Value.length == 0;
+  }
+
+  /**
    * Gets vr.
    *
    * @return the vr

--- a/src/main/java/com/quantumsoft/qupathcloud/entities/Series.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/entities/Series.java
@@ -79,7 +79,7 @@ public class Series {
    * @return the Series Description
    */
   public DicomAttribute<String> getSeriesDescription() {
-    if (seriesDescription == null) {
+    if (seriesDescription == null || seriesDescription.isEmpty()) {
       String temp = studyInstanceUID.getValue1() + seriesInstanceUID.getValue1();
       seriesDescription = new DicomAttribute<>();
       seriesDescription.setValue(new String[]{String.valueOf(temp.hashCode())});

--- a/src/main/java/com/quantumsoft/qupathcloud/synchronization/SynchronizationProjectWithDicomStore.java
+++ b/src/main/java/com/quantumsoft/qupathcloud/synchronization/SynchronizationProjectWithDicomStore.java
@@ -206,11 +206,13 @@ public class SynchronizationProjectWithDicomStore {
     List<Series> remoteImageSeriesList = DaoHelper.getImageSeries(remoteSeriesList);
 
     List<Series> seriesListInProject;
-    if (Files.notExists(metadataDirectory)) {
-      try {
-        Files.createDirectory(metadataDirectory);
-      } catch (IOException e) {
-        throw new QuPathCloudException(e);
+    if (!metadataConfiguration.exists()) {
+      if (Files.notExists(metadataDirectory)) {
+        try {
+          Files.createDirectory(metadataDirectory);
+        } catch (IOException e) {
+          throw new QuPathCloudException(e);
+        }
       }
       seriesListInProject = new ArrayList<>();
       seriesProcess(remoteImageSeriesList, metadataConfiguration, seriesListInProject);


### PR DESCRIPTION
- human-readable message if incoming instance is not a valid WSI dicom
- fix for interrupted sync getting permanently broken (was checking for metadata folder instead of index file in it)
- seriesDescription emptiness check did not expect present, but empty tag